### PR TITLE
Load flag icons from a CDN

### DIFF
--- a/components/locale-selector/locale.vue
+++ b/components/locale-selector/locale.vue
@@ -39,13 +39,6 @@ export default
 			type: Array
 			default: -> []
 
-	data: -> flag: null # Will store the path to the flag
-
-	# Load image from flag-icons NPM package
-	created: ->
-		@flag = await import("flag-icons/flags/4x3/#{@locale.countryCode}.svg")
-		@flag = @flag.default if @flag.default
-
 	computed:
 
 		# Make the URL to the flag icon from CDN

--- a/components/locale-selector/locale.vue
+++ b/components/locale-selector/locale.vue
@@ -48,6 +48,11 @@ export default
 
 	computed:
 
+		# Make the URL to the flag icon from CDN
+		flag: ->
+			endpoint = 'https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/6.6.2'
+			"#{endpoint}/flags/4x3/#{@locale.countryCode}.svg"
+
 		# The element to use on country links
 		countryLink: -> if @isLabel then 'span' else 'a'
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
 		"@cloak-app/utils": "^1.4.0",
 		"@nuxtjs/i18n": "^7.0.0",
 		"consola": "^2.15.3",
-		"flag-icons": "^6.2.0",
 		"lodash": "^4.0.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
The dynamic import ended up making JS chunks for every image, resulting in slower build times and long deploy logs