### PR TITLE
Improve SSG translation loading

### DIFF
--- a/plugins/fetch-translations.js
+++ b/plugins/fetch-translations.js
@@ -9,7 +9,7 @@ export default async function({ i18n, $craft, $config }, localeCode) {
 
 	// If JSON files are generated and this is being invoked on the client, use
 	// those JSON files.
-	if ($config.cloak.i18n.generateJson && process.client) {
+	if ($config.cloak.i18n.generateJson && process.client && process.static) {
 		try {
 			const generateDir = $config._app.basePath || "/";
 			const response = await fetch(`${generateDir}i18n/${localeCode}.json`);

--- a/plugins/fetch-translations.js
+++ b/plugins/fetch-translations.js
@@ -18,7 +18,7 @@ export default async function({ i18n, $craft, $config }, localeCode) {
 
 			// If not found, fallback to the CMS
 		} catch (e) {
-			console.error(e);
+			console.error("Couldn't load translations", e);
 		}
 	}
 


### PR DESCRIPTION
Only look for JSON if running in a statically generated context